### PR TITLE
For Go 1.22, the x/tools vendor needs to be updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9
-	golang.org/x/tools v0.3.0
+	golang.org/x/tools v0.17.0
 )
 
-require (
-	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
-)
+require golang.org/x/mod v0.14.0 // indirect


### PR DESCRIPTION
To fix an issue with building against a Go 1.22 toolchain, the x/tools vendor needs to be moved to a recent release.

See temporalio/sdk-go#1379 as a reference; the related Go change is https://github.com/golang/go/issues/62167