### PR TITLE
[from dev] merge: dont modify fuzzers

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,6 +240,15 @@ func isGoFile(info os.FileInfo) bool {
 	return true
 }
 
+// Checks whether a path is a non-test go file
+func isFuzzer(info os.FileInfo) bool {
+	ext := filepath.Ext(info.Name())
+	if strings.Contains(ext, "fuzz") {
+		return true
+	}
+	return false
+}
+
 // Check whether a parsed file uses the "io" package
 func (walker *Walker) usesIoPackage(file *ast.File) bool {
 	return astutil.UsesImport(walker.file, "io")
@@ -398,6 +407,9 @@ func validateFilePath(path string, info os.FileInfo) error {
 	// Do low-cost check on imports
 	if !utils.CheckImports(path) {
 		return fmt.Errorf("Skip file")
+	}
+	if isFuzzer(info) {
+		return fmt.Errorf("Will not sanitize fuzzers")
 	}
 	return nil
 }


### PR DESCRIPTION
@AdamKorcz is there any reason this last change from `dev` can't/shouldn't be in `main`? Containerd is using `dev` via the Dockerfile for it in the google ossfuzz project, but I just made those changes to `main` for the fix to Go 1.22 compilation.

If this shouldn't be in main, then I can cherry-pick those go.mod/go.sum updates into `dev`, but thought I would check as everything else from dev is already in main. You can let me know by closing this PR if this shouldn't be in `main` and I can make the changes in `dev` instead.